### PR TITLE
Feature #28: Evaluating the average amount of non-zero genes.

### DIFF
--- a/data/analysis.py
+++ b/data/analysis.py
@@ -65,11 +65,23 @@ class Analysis:
         # each column corresponds to a gene
         n_genes = self.adata.n_vars
 
+        # get the average amount of non-zero genes per cell by counting how many genes have a non-zero signal and dividing by the amount of cells.
+        total_non0_genes = 0
+        for i in range(n_cells):     
+            for j in range(n_genes): 
+                if(self.adata.X[i,j] != 0): total_non0_genes = (total_non0_genes + 1)
+        
+        avg_non0_genes = total_non0_genes/n_cells
+            
+        
+        # test = self.adata.X[1,1]
+
         output = ""
         output += "Dataset overview:" + "\n"
-        output += "----------------------------------------" + "\n"
+        output += "----------------------------------------------------------------------------------------------------------" + "\n"
         output += "Number of cells: " + str(n_cells) + "\n"
-        output += "Number of genes: " + str(n_genes)
+        output += "Number of genes: " + str(n_genes) + "\n"
+        output += "Average amount of non-zero signal genes: " + str(avg_non0_genes)
 
         return output
 

--- a/data/analysis.py
+++ b/data/analysis.py
@@ -73,9 +73,6 @@ class Analysis:
         
         avg_non0_genes = total_non0_genes/n_cells
             
-        
-        # test = self.adata.X[1,1]
-
         output = ""
         output += "Dataset overview:" + "\n"
         output += "----------------------------------------------------------------------------------------------------------" + "\n"


### PR DESCRIPTION
## Motivation

Resolves #28 
These changes allow the user to see the average amount of non-zero signal genes within the uploaded loom file, as specified in the user story: **As a user I want to get the average non-zero signal genes**

## Changes

I added a double loop that goes through the entire cell/gene matrix and counts the amount of matrix cells, whose contents aren't 0. This total amount of non-zero signal genes is then divided by the amount of cells to determine the average amount of non-zero signal genes in the data set.
This number is then displayed alongside the other basic information, when the user runs the basic overview.

## Testing

I tested the changes with the neuron_labeling.loom file, by uploading the file to the program and running the basic overview. It produced an average of about ~57 non-zero signal genes per cell and displayed the information alongside the amount of different genes and cells.
