### PR TITLE
Feature #26: Find cells with min/max non-zero signal genes

### DIFF
--- a/data/analysis.py
+++ b/data/analysis.py
@@ -26,6 +26,9 @@ class Analysis:
 
         Args:
             fh (FileHandler): The file handler storing the currently loaded file path.
+
+        Returns:
+            Whether one needs to update the stored data because the file is new.
         """
 
         # get the path of the currently loaded file
@@ -38,7 +41,7 @@ class Analysis:
             # and update the file path of this object
             self.file_path = current_path
             return True
-        
+
         return False
 
     def no_data(self):
@@ -69,24 +72,26 @@ class Analysis:
         # each column corresponds to a gene
         n_genes = self.adata.n_vars
 
-        if (maybe_upate == True):
-            # get the average amount of non-zero genes per cell by counting how many genes have a non-zero signal and dividing by the amount of cells.
+        # only do costly operations when there is an update required
+        if (maybe_upate):
+            # get the average amount of non-zero genes per cell by counting how many genes have a non-zero signal and dividing by the amount of cells
             total_non_0_genes = 0
-            for i in range(n_cells):     
-                for j in range(n_genes): 
-                    if(self.adata.X[i,j] != 0): total_non_0_genes = (total_non_0_genes + 1)
-        
+            for i in range(n_cells):
+                for j in range(n_genes):
+                    if (self.adata.X[i, j] != 0):
+                        total_non_0_genes += 1
+
             avg_non_0_genes = total_non_0_genes/n_cells
             # Save the calculated value as a parameter of the analysis.
             self.avg_non_0_signal_genes = avg_non_0_genes
 
-            
         output = ""
         output += "Dataset overview:" + "\n"
         output += "----------------------------------------------------------------------------------------------------------" + "\n"
         output += "Number of cells: " + str(n_cells) + "\n"
         output += "Number of genes: " + str(n_genes) + "\n"
-        output += "Average amount of non-zero signal genes: " + str(self.avg_non_0_signal_genes)
+        output += "Average amount of non-zero signal genes: " + \
+            str(self.avg_non_0_signal_genes)
 
         return output
 
@@ -95,7 +100,7 @@ class Analysis:
         Creates the UMAP projections.
         """
 
-        maybe_upate = self.update(fh)
+        self.update(fh)
 
         if self.no_data():
             return

--- a/ui/main_menu.py
+++ b/ui/main_menu.py
@@ -344,6 +344,10 @@ class UI:
         Performs the data overview.
         """
 
+        # destroy the potential old label first
+        if self.data_overview_label:
+            self.data_overview_label.destroy()
+
         try:
             self.do_pre_window.destroy()
             self.enable_loading_panel()
@@ -351,10 +355,6 @@ class UI:
             do_string = self.analysis.data_overview(self.fh)
 
             self.disable_loading_panel()
-
-            # destroy the potential old label first
-            if self.data_overview_label:
-                self.data_overview_label.destroy()
 
             # add the data_overview_label
             self.data_overview_label = Label(self.vis_canvas)

--- a/user/data_overview/my_data_overview.txt
+++ b/user/data_overview/my_data_overview.txt
@@ -1,6 +1,9 @@
 File: D:/Finn der Zocker/Documents/Teamprojekt-Repo/Teamproject-2023/examples/neuron_labeling.loom
 
 Dataset overview:
-----------------------------------------
+----------------------------------------------------------------------------------------------------------
 Number of cells: 3060
 Number of genes: 97
+Average amount of non-zero signal genes: 57.59346405228758
+Cell with fewest non-zero signal genes: 527 (n=21)
+Cell with most non-zero signal genes: 580 (n=93)


### PR DESCRIPTION
<!-- Please set the title to "label #issue-number: short description" -->

## Motivation

Resolves #26 

## Changes

<!-- Describe the changes you made and why you made them here -->
I've made some very small refactorings and one improvement concerning the destruction of the data overview field every time so that when there is an error occuring for a new file the old field gets destroyed. But the main change is that I've extended the data overview so that it now shows the cell with fewest and the cell with most non-zero signal genes and also the number of them for both cells. It prints the cell first, followed by the number in brackets `(n=123)`. Note that if there is more than one min/max cell, the data overview will only show the first one of them because otherwise one would not have any guarantees about how many cells possibly exist having the same number.

## Testing

<!-- Describe how you tested these changes -->
Using the two example files `neuron_labelling` and `test_from_loompy`. The former one creates some nice results whereas the second one shows what happens if all cells have the same number (0) -> it takes the first cell with index 0.

## Additional context

<!-- Use this space to communicate potential concerns with the reviewer 
or to provide additional context to these changes -->