### PR TITLE
Improvement #78: Improve understandability of data overview

### DIFF
--- a/data/analysis.py
+++ b/data/analysis.py
@@ -120,10 +120,10 @@ class Analysis:
             str(self.avg_non_0_signal_genes) + "\n"
         output += "Cell with fewest non-zero signal genes: " + \
             str(self.min_cell_non_0_genes) + \
-            " (n=" + str(self.min_num_non_0_genes) + ")" + "\n"
+            " (" + str(self.min_num_non_0_genes) + " genes)" + "\n"
         output += "Cell with most non-zero signal genes: " + \
             str(self.max_cell_non_0_genes) + \
-            " (n=" + str(self.max_num_non_0_genes) + ")"
+            " (" + str(self.max_num_non_0_genes) + " genes)"
 
         return output
 

--- a/user/data_overview/my_data_overview.txt
+++ b/user/data_overview/my_data_overview.txt
@@ -5,5 +5,5 @@ Dataset overview:
 Number of cells: 3060
 Number of genes: 97
 Average amount of non-zero signal genes: 57.59346405228758
-Cell with fewest non-zero signal genes: 527 (n=21)
-Cell with most non-zero signal genes: 580 (n=93)
+Cell with fewest non-zero signal genes: 527 (21 genes)
+Cell with most non-zero signal genes: 580 (93 genes)


### PR DESCRIPTION
<!-- Please set the title to "label #issue-number: short description" -->

## Motivation

Resolves #78 

## Changes

<!-- Describe the changes you made and why you made them here -->
Simple change of the text displaying the cell with minimum and maximum number of non-zero signal genes. Before it was `527 (n=21)`, now it is `527 (21 genes)` so that it is clearer what the two numbers mean: Cell and number of those genes. I hope this is clear now, I think anything else would be too long (like `(21 non-zero signal genes)` or `cell: 527, genes: 21` and therefore decrease the clarity of the data overview.

## Testing

<!-- Describe how you tested these changes -->
Program worked before and I did not changed any interesting things. Still ran it and no problems.

## Additional context

<!-- Use this space to communicate potential concerns with the reviewer 
or to provide additional context to these changes -->